### PR TITLE
Update localization.js

### DIFF
--- a/localization.js
+++ b/localization.js
@@ -382,7 +382,7 @@ var loc_strings = {
     "Svenska": {
         "author": "Svensk översättning av <a href='https://forums.kleientertainment.com/profile/912865-captain_rage/'>Captain Rage</a>",
         "locale": "sv",
-        "progress_communityunlocks": "Gemensamt upplåsta mål",
+        "progress_communityunlocks": "Upplåsta gemensamma mål",
         "progress_bar_title": "Förlopp: %1%",
         "progress_locked": "Låst",
         "progress_beetletaur": "Infernaliska cyklopsvinet",
@@ -432,9 +432,9 @@ var loc_strings = {
             "ordinal": function(number) {
                 var b = number % 10,
                     output = (~~(number % 100 / 10) === 1) ? 'e' :
-                    (b === 1) ? 'a' :
-                    (b === 2) ? 'a' :
-                    (b === 3) ? 'e' : 'e';
+                    (b === 1) ? ':a' :
+                    (b === 2) ? ':a' :
+                    (b === 3) ? ':e' : ':e';
                 return number + "<span class='ordinal'>" + output + "</span>";
             }
         },


### PR DESCRIPTION
'Gementsamt upplåsta mål' -> 'Upplåsta gemensamma mål'.
Ordinal numbers: första, andra, tredje, n:te; ':a', ':a', ':e', ':e'.

EDIT:
Oh, thanks alot for fixing the ordinal numbers! I accidentally omitted those. Now they will adhere to the Swedish format as well.